### PR TITLE
major updates to stimulus presentations data formatting

### DIFF
--- a/brain_observatory_utilities/datasets/behavior/data_formatting.py
+++ b/brain_observatory_utilities/datasets/behavior/data_formatting.py
@@ -1,6 +1,8 @@
+import numpy as np
 import pandas as pd
+
 from allensdk.brain_observatory.behavior.trials_processing import calculate_reward_rate
-from brain_observatory_utilities.utilities.general_utilities import get_trace_average
+from brain_observatory_utilities.utilities import general_utilities as utilities
 import brain_observatory_utilities.datasets.behavior.data_access as data_access
 
 
@@ -47,7 +49,7 @@ def add_mean_running_speed_to_stimulus_presentations(stimulus_presentations,
     '''
 
     stim_running_speed = stimulus_presentations.apply(
-        lambda row: get_trace_average(
+        lambda row: utilities.get_trace_average(
             running_speed['speed'].values,
             running_speed['timestamps'].values,
             row["start_time"] + time_window[0],
@@ -56,7 +58,8 @@ def add_mean_running_speed_to_stimulus_presentations(stimulus_presentations,
     return stimulus_presentations
 
 
-def add_mean_pupil_to_stimulus_presentations(stimulus_presentations, eye_tracking, column_to_use='pupil_area', time_window=[0, 0.75]):
+def add_mean_pupil_to_stimulus_presentations(stimulus_presentations, eye_tracking,
+                                             column_to_use='pupil_area', time_window=[0, 0.75]):
     '''
     Append a column to stimulus_presentations which contains
     the mean pupil area, diameter, or radius in a range relative to
@@ -98,7 +101,7 @@ def add_mean_pupil_to_stimulus_presentations(stimulus_presentations, eye_trackin
 
     eye_tracking_timeseries = eye_tracking[column_to_use].values
     mean_pupil_around_stimulus = stimulus_presentations.apply(
-        lambda row: get_trace_average(
+        lambda row: utilities.get_trace_average(
             eye_tracking_timeseries,
             eye_tracking['timestamps'].values,
             row["start_time"] + time_window[0],
@@ -108,13 +111,11 @@ def add_mean_pupil_to_stimulus_presentations(stimulus_presentations, eye_trackin
     return stimulus_presentations
 
 
-def add_rewards_to_stimulus_presentations(stimulus_presentations,
-                                          rewards,
-                                          time_window=[0,3]):
+def add_rewards_to_stimulus_presentations(stimulus_presentations, rewards, time_window=[0,0.75]):
     '''
-    Append a column to stimulus_presentations which contains
-    the timestamps of rewards that occur
-    in a range relative to the onset of the stimulus.
+    Append a column called 'rewards', to stimulus_presentations which contains the timestamps of rewards that occured
+    in a range relative to the onset of the stimulus, as well as a Boolean column
+    called 'rewarded' which indicates whether there was a reward delivered on a given stimulus presentation or not
 
     Args:
         stimulus_presentations (pd.DataFrame): dataframe of
@@ -152,19 +153,19 @@ def add_rewards_to_stimulus_presentations(stimulus_presentations,
         axis=1,
     )
     stimulus_presentations["rewards"] = rewards_each_stim
+    stimulus_presentations['rewarded'] = [True if len(rewards) > 0 else False for rewards in
+                                          stimulus_presentations.rewards.values]
     return stimulus_presentations
 
 
-def add_licks_to_stimulus_presentations(stimulus_presentations,
-                                        licks,
-                                        time_window=[0, 0.75]):
+def add_licks_to_stimulus_presentations(stimulus_presentations, licks, time_window=[0, 0.75]):
     '''
     Append a column to stimulus_presentations which
     contains the timestamps of licks that occur
     in a range relative to the onset of the stimulus.
 
     Args:
-        stimulus_presentations (pd.DataFrame): 
+        stimulus_presentations (pd.DataFrame):
             dataframe of stimulus presentations.
             Must contain: 'start_time'
         licks (pd.DataFrame): lick dataframe. Must contain 'timestamps'
@@ -192,6 +193,7 @@ def add_licks_to_stimulus_presentations(stimulus_presentations,
         stimulus_presentations = add_licks_to_stimulus_presentations(stimulus_presentations, licks)
     '''
 
+    stimulus_presentations = stimulus_presentations.copy()
     lick_times = licks['timestamps'].values
     licks_each_stim = stimulus_presentations.apply(
         lambda row: lick_times[
@@ -199,11 +201,19 @@ def add_licks_to_stimulus_presentations(stimulus_presentations,
         axis=1,
     )
     stimulus_presentations["licks"] = licks_each_stim
+
+    stimulus_presentations['licked'] = [True if len(licks) > 0 else False for licks in stimulus_presentations.licks.values]
+    stimulus_presentations['lick_on_next_flash'] = stimulus_presentations['licked'].shift(-1)
+    stimulus_presentations['lick_latency'] = [stimulus_presentations.iloc[row].licks[0] -
+                                              stimulus_presentations.iloc[row].start_time if
+                                              len(stimulus_presentations.iloc[row].licks) > 0 else
+                                              np.nan for row in range(len(stimulus_presentations))]
+
+
     return stimulus_presentations
 
 
-def add_reward_rate_to_stimulus_presentations(stimulus_presentations,
-                                              trials):
+def add_reward_rate_to_stimulus_presentations(stimulus_presentations, trials):
     '''
     Parameters:
     ____________
@@ -267,58 +277,407 @@ def add_epochs_to_stimulus_presentations(stimulus_presentations, time_column='st
     return stimulus_presentations
 
 
-def add_trials_id_to_stimulus_presentations(stimulus_presentations, trials):
+def add_change_trials_id_to_stimulus_presentations(stimulus_presentations, trials):
     """
-    Add trials_id to stimulus presentations by finding the closest change time to each stimulus start time
-    If there is no corresponding change time, the trials_id is NaN
+    Add trials_id for change and sham change times to stimulus presentations by
+    finding the closest change (or sham change) time to each stimulus start time.
+    Column is called 'change_trials_id' to distinguish from 'trials_id' which is applied to all flashes in a trial
+    If there is no corresponding change (or sham change) time, the change_trials_id is NaN
+    i.e. this function only assigns a trials_id to the stimulus presentations corresponding to go and catch trials as defined in the trials table.
+    If you want to assign trials_id to every stimulus presentation that is part of a trial, use
+        add_trials_id_to_stimulus_presentations
     :param: stimulus_presentations: stimulus_presentations attribute of BehaviorOphysExperiment object, must have 'start_time'
     :param trials: trials attribute of BehaviorOphysExperiment object, must have 'change_time'
     """
-    # for each stimulus_presentation, find the trials_id that is closest to the start time
-    # add to a new column called 'trials_id'
-    for idx, stimulus_presentation in stimulus_presentations.iterrows():
-        start_time = stimulus_presentation['start_time']
-        query_string = 'change_time > @start_time - 1 and change_time < @start_time + 1'
-        trials_id = (np.abs(start_time - trials.query(query_string)['change_time']))
-        if len(trials_id) == 1:
-            trials_id = trials_id.idxmin()
+    # for each stimulus_presentation, find the change_time that is closest to the start time
+    # then add the corresponding trials_id to stimulus_presentations
+    trials = trials.copy()
+    stimulus_presentations = stimulus_presentations.copy()
+    for row in range(len(stimulus_presentations)):
+        this_start_time = stimulus_presentations.iloc[row].start_time
+        # if its not the last row / stimulus presentation
+        if row <= len(stimulus_presentations)-2:
+            # get the start time of the next stimulus
+            next_start_time = stimulus_presentations.iloc[row+1].start_time
+        else:
+            # if it is the last row, infer that the next start would be 750ms from now
+            next_start_time = stimulus_presentations.iloc[row].start_time + 0.75
+        # find the trial where change time falls between the current and next stimulus start times
+        trial_data = trials[(trials.change_time>this_start_time) & (trials.change_time<=next_start_time)]
+        if len(trial_data) > 0:
+            trials_id = trial_data.index.values[0]
         else:
             trials_id = np.nan
-        stimulus_presentations.loc[idx, 'trials_id'] = trials_id
+        stimulus_presentations.loc[row, 'change_trials_id'] = trials_id
     return stimulus_presentations
 
 
-def add_trials_data_to_stimulus_presentations_table(stimulus_presentations, trials):
+def add_change_trial_outcomes_to_stimulus_presentations(stimulus_presentations, trials):
     """
-    Add trials_id to stimulus presentations table then join relevant columns of trials with stimulus_presentations
+    Add trials_id to stimulus presentations table, just for go and catch trials,
+    then join columns of trials table indicating whether a go trial was hit or miss
+    and whether a catch trial was a false alarm or correct reject
+    with stimulus_presentations,
+    relevant columns here are
     :param: stimulus_presentations: stimulus_presentations attribute of BehaviorOphysExperiment object, must have 'start_time'
     :param trials: trials attribute of BehaviorOphysExperiment object, must have 'change_time'
     """
     # add trials_id and merge to get trial type information
-    stimulus_presentations = add_trials_id_to_stimulus_presentations(stimulus_presentations, trials)
+    stimulus_presentations = add_change_trials_id_to_stimulus_presentations(stimulus_presentations, trials)
     # only keep certain columns
-    trials = trials[['change_time', 'go', 'catch', 'aborted', 'auto_rewarded',
-                    'hit', 'miss', 'false_alarm', 'correct_reject',
-                    'response_time', 'response_latency', 'reward_time', 'reward_volume', ]]
+    trials = trials[['change_time', 'hit', 'miss',
+                     'false_alarm', 'correct_reject',
+                     'reward_time', 'reward_volume']]
     # merge trials columns into stimulus_presentations
+
+    stimulus_presentations = stimulus_presentations.reset_index().merge(trials, left_on='change_trials_id',
+                                                                        right_on='trials_id', how='left')
+    stimulus_presentations = stimulus_presentations.set_index('stimulus_presentations_id')
+    return stimulus_presentations
+
+
+def add_trials_id_to_stimulus_presentations(stimulus_presentations, trials):
+    """
+    Add trials_id to stimulus presentations by finding the closest trial start_time to each stimulus start_time
+    This function adds a trials_id to every stimulus presentation based on which trial each stimulus belongs to
+    If you want to assign trials_id only to stimulus presentations corresponding to go and catch trials as defined in the trials table, use:
+        add_change_trials_id_to_stimulus_presentations
+    :param: stimulus_presentations: stimulus_presentations attribute of BehaviorOphysExperiment object, must have 'start_time'
+    :param trials: trials attribute of BehaviorOphysExperiment object, must have 'start_time'
+    """
+
+    # add trials_id and trial_stimulus_index
+    stimulus_presentations = stimulus_presentations.copy()
+    stimulus_presentations['trials_id'] = np.searchsorted(trials.start_time, stimulus_presentations.start_time) -1 # subtract 1 so its indexed at zero
+
+    return stimulus_presentations
+
+
+def add_trial_type_to_stimulus_presentations(stimulus_presentations, trials):
+    """
+    Add trials_id to stimulus presentations table
+    then join trial type columns of trials table with stimulus_presentations
+    trial types = ['aborted', 'auto_rewarded', 'go', 'catch']
+    :param: stimulus_presentations: stimulus_presentations attribute of BehaviorOphysExperiment object, must have 'start_time'
+    :param trials: trials attribute of BehaviorOphysExperiment object, must have 'start_time'
+    """
+    # add trials_id for all stimulus presentations and merge to get trial type information
+    stimulus_presentations = add_trials_id_to_stimulus_presentations(stimulus_presentations, trials)
+    # get trial type columns
+    trials = trials[['go', 'catch', 'aborted', 'auto_rewarded']]
+    # merge trial type columns into stimulus_presentations
     stimulus_presentations = stimulus_presentations.reset_index().merge(trials, on='trials_id', how='left')
     stimulus_presentations = stimulus_presentations.set_index('stimulus_presentations_id')
     return stimulus_presentations
 
 
+def add_stimulus_count_within_trial_to_stimulus_presentations(stimulus_presentations, trials):
+    """
+    Add a column to stimulus_presentations that indicates how many stimuli have been shown since the trial start
+
+    :param: stimulus_presentations: stimulus_presentations attribute of BehaviorOphysExperiment object, must have 'start_time'
+    :param trials: trials attribute of BehaviorOphysExperiment object, must have 'start_time'
+    """
+    stimulus_presentations = stimulus_presentations.copy()
+    # if trials_id is not a column of stimulus_presentations, add it
+    if 'trials_id' not in stimulus_presentations.keys():
+        stimulus_presentations = add_trials_id_to_stimulus_presentations(stimulus_presentations, trials)
+
+    # label each stimulus presentation based on the number of stimuli since the trial start
+    stimulus_presentations['stimulus_count_within_trial'] = None
+    stimulus_count_within_trial = 0
+    last_trial_id = -1 # start at -1 as baseline to compare with first trials_id (which is 0)
+    # iterate over every stimulus
+    for idx, row in stimulus_presentations.iterrows():
+        trials_id = row.trials_id
+        # if trials_id is the same as the last trial, increment stimulus_count_within_trial
+        if trials_id == last_trial_id:
+            stimulus_count_within_trial += 1
+        else:
+            stimulus_count_within_trial = 0
+            # the current trial will be the last_trial_id for the next row / iteration
+            last_trial_id = trials_id
+        stimulus_presentations.at[idx, 'stimulus_count_within_trial'] = stimulus_count_within_trial
+
+    return stimulus_presentations
+
+
+def add_could_change_to_stimulus_presentations(stimulus_presentations, trials, licks):
+    """
+    Adds a column called could_change to the stimulus presentations table that indicates whether a given
+    stimulus presentation could have been a change or sham change based on the known change time distribution.
+    A stimulus could change if it is at least 4 stimulus flashes after the trial start,
+    and there was not a lick on the previous stimulus, and the current or next stimulus is not omitted.
+    :param stimulus_presentations: SDK stimulus presentations table
+    :param trials: SDK trials table
+    :return:
+    """
+
+    licks = licks.copy()
+    trials = trials.copy()
+    stimulus_presentations = stimulus_presentations.copy()
+    # if trials_id is not a column of stimulus_presentations, add it
+    if 'trials_id' not in stimulus_presentations.keys():
+        stimulus_presentations = add_trials_id_to_stimulus_presentations(stimulus_presentations, trials)
+        # if trials_id is not a column of stimulus_presentations, add it
+    if 'licks' not in stimulus_presentations.keys():
+        stimulus_presentations = add_licks_to_stimulus_presentations(stimulus_presentations, licks)
+        # if trials_id is not a column of stimulus_presentations, add it
+    if 'stimulus_count_within_trial' not in stimulus_presentations.keys():
+        stimulus_presentations = add_stimulus_count_within_trial_to_stimulus_presentations(stimulus_presentations, trials)
+
+    # add previous_image_name
+    stimulus_presentations['previous_image_name'] = stimulus_presentations['image_name'].shift()
+    # add previous_response_on_trial
+    stimulus_presentations['previous_response_on_trial'] = False
+    stimulus_presentations['previous_change_on_trial'] = False
+    # set 'stimulus_presentations_id' and 'trials_id' as indices to speed lookup
+    stimulus_presentations = stimulus_presentations.reset_index().set_index(['stimulus_presentations_id', 'trials_id'])
+    for idx, row in stimulus_presentations.iterrows():
+        stim_id, trials_id = idx
+        # get all stimuli before the current on the current trial
+        mask = (stimulus_presentations.index.get_level_values(0) < stim_id) & (
+            stimulus_presentations.index.get_level_values(1) == trials_id)
+        # check to see if any previous stimuli have a response lick
+        stimulus_presentations.at[idx, 'previous_response_on_trial'] = stimulus_presentations[mask]['licked'].any()
+        stimulus_presentations.at[idx, 'previous_change_on_trial'] = stimulus_presentations[mask]['is_change'].any()
+    # set the index back to being just 'stimulus_presentations_id'
+    stimulus_presentations = stimulus_presentations.reset_index().set_index('stimulus_presentations_id')
+
+    # add could_change column to indicate whether the stimulus presentation falls into the range in which changes can occur
+    stimulus_presentations['could_change'] = False
+    for idx, row in stimulus_presentations.iterrows():
+        # check if we meet conditions where a change could occur on this stimulus (at least 4th flash of trial, no previous change on trial)
+        # changes can only happen after the 4th stimulus within a trial
+        # changes can only happen if there is no previous response on the trial (i.e. not on aborted trials)
+        # changes can only happen if there is no previous change on that trial (i.e. not during the grace period / consumption window)
+        # changes can only happen if the previous stimulus was not omitted
+        if row['stimulus_count_within_trial'] >= 4 and row['previous_response_on_trial'] is False \
+                and row['previous_change_on_trial'] is False \
+                and row['image_name'] != 'omitted' \
+                and row['previous_image_name'] != 'omitted':
+            stimulus_presentations.at[idx, 'could_change'] = True
+
+    return stimulus_presentations
+
 
 def add_time_from_last_change_to_stimulus_presentations(stimulus_presentations):
     '''
-    Adds a column to stimulus_presentations called 'time_from_last_change', which is the time, in seconds since the last image change
+    Adds a column to stimulus_presentations called 'time_from_last_change',
+    which is the time, in seconds since the last image change
 
-    ARGS: SDK session object
+    ARGS: SDK stimulus presentations table
     MODIFIES: session.stimulus_presentations
     RETURNS: stimulus_presentations
     '''
     stimulus_times = stimulus_presentations["start_time"].values
     change_times = stimulus_presentations.query('is_change')['start_time'].values
-    time_from_last_change = general_utilities.time_from_last(stimulus_times, change_times)
-    stimulus_presentations["time_from_last_change"] = time_from_last_change
+    time_from_last_change = utilities.time_from_last(stimulus_times, change_times)
+    stimulus_presentations["time_from_last_is_change"] = time_from_last_change
 
     return stimulus_presentations
 
+
+def add_time_from_last_omission_to_stimulus_presentations(stimulus_presentations):
+    '''
+    Adds a column to stimulus_presentations called 'time_from_last_omission',
+    which is the time, in seconds since the last stimulus omission
+
+    ARGS: SDK stimulus presentations table
+    MODIFIES: session.stimulus_presentations
+    RETURNS: stimulus_presentations
+    '''
+    stimulus_times = stimulus_presentations["start_time"].values
+    omission_times = stimulus_presentations.query('omitted')['start_time'].values
+    time_from_last_omission = utilities.time_from_last(stimulus_times, omission_times)
+    stimulus_presentations["time_from_last_omitted"] = time_from_last_omission
+
+    return stimulus_presentations
+
+
+def add_time_from_last_lick_to_stimulus_presentations(stimulus_presentations, licks):
+    '''
+    Adds a column to stimulus_presentations called 'time_from_last_lick',
+    which is the time, in seconds since the last lick response
+
+    ARGS: SDK stimulus presentations table, SDK licks table
+    MODIFIES: session.stimulus_presentations
+    RETURNS: stimulus_presentations
+    '''
+
+    stimulus_presentations = stimulus_presentations.copy()
+
+    stimulus_times = stimulus_presentations["start_time"].values
+    lick_times = licks.timestamps.values
+    time_from_last_lick = utilities.time_from_last(stimulus_times, lick_times)
+    stimulus_presentations["time_from_last_lick"] = time_from_last_lick
+
+    return stimulus_presentations
+
+
+def add_time_from_last_reward_to_stimulus_presentations(stimulus_presentations, rewards):
+    '''
+    Adds a column to stimulus_presentations called 'time_from_last_reward',
+    which is the time, in seconds since the last reward was delivered
+
+    ARGS: SDK stimulus presentations table, SDK rewards table
+    MODIFIES: session.stimulus_presentations
+    RETURNS: stimulus_presentations
+    '''
+    stimulus_times = stimulus_presentations["start_time"].values
+    reward_times = rewards.timestamps.values
+    time_from_last_reward = utilities.time_from_last(stimulus_times, reward_times)
+    stimulus_presentations["time_from_last_reward"] = time_from_last_reward
+
+    return stimulus_presentations
+
+
+def add_time_from_last_to_stimulus_presentations(stimulus_presentations, licks, rewards):
+    """
+    Adds multiple columns to stimulus presentations with the number of stimuli that have elapsed
+    since the last change, omission, lick, and reward using the Boolean columns 'is_change', 'omitted', 'licked', and 'rewarded'
+    If these Boolean columns are not included in stimulus_presentations, they will be added
+
+    :param stimulus_presentations: SDK stimulus_presentations table
+    :return: stimulus_presentations with 'stimulus_count_from_last' columns added
+
+    """
+    stimulus_presentations = stimulus_presentations.copy()
+    stimulus_presentations = add_time_from_last_change_to_stimulus_presentations(stimulus_presentations)
+    stimulus_presentations = add_time_from_last_omission_to_stimulus_presentations(stimulus_presentations)
+    stimulus_presentations = add_time_from_last_reward_to_stimulus_presentations(stimulus_presentations, rewards)
+    stimulus_presentations = add_time_from_last_lick_to_stimulus_presentations(stimulus_presentations, licks)
+
+    return stimulus_presentations
+
+
+def stimulus_count_from_last(stimulus_presentations, column_to_count_from='is_change'):
+    """
+    Takes a Boolean column in stimulus_presentations and counts the number of stimulus presentations
+    after each True instance of the column_to_count_from column value,
+    adds a column called 'stimulus_count_from_last_'+column_to_count_from that contains that count value
+
+    Example: if using column_to_count_from = 'is_change', and the first 10 stimuli are [F, F, F, F, T, F, F, F, F],
+    the [stimulus_count_since_last_is_change' column will be [1, 2, 3, 4, 0, 1, 2, 3, 4]
+
+    :param stimulus_presentations: SDK stimulus presentations table, must include Boolean column for column_to_count_from
+    :param column_to_count_from: column value in stimulus_presentations to use to count number of stimulus presentations
+                                since the column value was last True
+    :return: stimulus_presentations with added column 'stimulus_count_from_last_'+column_to_count_from
+    """
+    stimulus_presentations = stimulus_presentations.copy()
+    # label each stimulus presentation based on the number of stimuli since the trial start
+    stimulus_presentations['stimulus_count_from_last_' + column_to_count_from] = None
+    stimulus_count = 0
+    # iterate over every stimulus
+    for idx, row in stimulus_presentations.iterrows():
+        current_value = row[column_to_count_from]
+        # if current_value is not True, increment the counter
+        if current_value == False:
+            stimulus_count += 1
+        elif current_value == True:  # if current value is True, reset the counter
+            stimulus_count = 0
+        else:
+            stimulus_count = np.nan
+        stimulus_presentations.at[idx, 'stimulus_count_from_last_' + column_to_count_from] = stimulus_count
+
+    return stimulus_presentations
+
+
+def add_stimulus_count_from_last_to_stimulus_presentations(stimulus_presentations, licks, rewards):
+    """
+    Adds multiple columns to stimulus presentations with the number of stimuli that have elapsed
+    since the last change, omission, lick, and reward using the Boolean columns 'is_change', 'omitted', 'licked', and 'rewarded'
+    If these Boolean columns are not included in stimulus_presentations, they will be added
+
+    :param stimulus_presentations: SDK stimulus_presentations table
+    :return: stimulus_presentations with 'stimulus_count_from_last' columns added
+
+    """
+    stimulus_presentations = stimulus_presentations.copy()
+    if 'licked' not in stimulus_presentations.keys():
+        stimulus_presentations = add_licks_to_stimulus_presentations(stimulus_presentations, licks,
+                                                                              time_window=[0, 0.75])
+    if 'rewarded' not in stimulus_presentations.keys():
+        stimulus_presentations = add_rewards_to_stimulus_presentations(stimulus_presentations, rewards,
+                                                                                time_window=[0, 0.75])
+    for column in ['is_change', 'omitted', 'licked', 'rewarded']:
+        stimulus_presentations = stimulus_count_from_last(stimulus_presentations, column_to_count_from=column)
+
+    return stimulus_presentations
+
+
+def add_behavior_info_to_stimulus_presentations(stimulus_presentations, trials, licks, rewards,
+                                                running_speed, eye_tracking):
+    """
+    Adds a variety of useful columns to the stimulus presentations table by incorporating information
+    from the trials, licks, rewards, running_speed and eye_tracking tables.
+    Useful to filter stimuli based on behavioral information.
+    Added columns include trials_id, go, catch, aborted, auto-rewarded, hit, miss, false_alarm, correct_reject,
+    as well as lick and reward times for each stimulus presentation,
+    reward rate in rewards / min (computed across trials not stimulus presentations),
+    and mean running speed and pupil width for each stimulus
+
+    :param stimulus_presentations: SDK stimulus_presentations table
+    :param trials: SDK trials table
+    :param licks: SDK licks table
+    :param rewards: SDK rewards table
+    :param running_speed: SDK running_speed table
+    :param eye_tracking: SDK eye tracking table, will use pupil_width column of eye tracking table
+    :return:
+    """
+
+    stimulus_presentations = stimulus_presentations.copy()
+    # add columns from trials table: ['change_time', 'hit', 'miss', 'false_alarm', 'correct_reject', 'reward_time', 'reward_volume']
+    # applied only to stimulus presentations corresponding to change and sham change times (go and catch)
+    stimulus_presentations = add_change_trials_id_to_stimulus_presentations(stimulus_presentations, trials)
+    stimulus_presentations = add_change_trial_outcomes_to_stimulus_presentations(stimulus_presentations, trials)
+    # add columns from trials table: ['go', 'catch', 'aborted', 'auto_rewarded']
+    # applied to all stimulus presentations belonging to that trial
+    stimulus_presentations = add_trials_id_to_stimulus_presentations(stimulus_presentations, trials)
+    stimulus_presentations = add_trial_type_to_stimulus_presentations(stimulus_presentations, trials)
+    # add the timing of licks and rewards for each stimulus presentation
+    stimulus_presentations = add_licks_to_stimulus_presentations(stimulus_presentations, licks, time_window=[0, 0.75])
+    stimulus_presentations = add_rewards_to_stimulus_presentations(stimulus_presentations, rewards, time_window=[0, 0.75])
+    # add reward rate across trials to stimulus presentations
+    stimulus_presentations = add_reward_rate_to_stimulus_presentations(stimulus_presentations, trials)
+    # add mean running speed and pupil diameter for each stimulus presentation
+    stimulus_presentations = add_mean_running_speed_to_stimulus_presentations(stimulus_presentations, running_speed, time_window=[0, 0.75])
+    stimulus_presentations = add_mean_pupil_to_stimulus_presentations(stimulus_presentations, eye_tracking,
+                                             column_to_use='pupil_width', time_window=[0, 0.75])
+
+    return stimulus_presentations
+
+
+def add_timing_info_to_stimulus_presentations(stimulus_presentations, trials, licks, rewards):
+    """
+    Annotate stimulus presentations table with information about timing relative to events of interest,
+    such as time from last change / omission / lick / reward,
+    whether a stimulus was before or after a change or an omission,
+    and whether a given stimulus could have been a change based on known change time distribution (4-12 flashes from the time of the last lick)
+
+    :param stimulus_presentations: SDK stimulus presentations table
+    :param trials: SDK trials table
+    :param licks: SDK licks table
+    :param rewards: SDK rewards table
+    :return:
+    """
+
+    # add columns indicating wither previous or subsequent stimulus presentations are a change or omission
+    stimulus_presentations['pre_change'] = stimulus_presentations['is_change'].shift(-1)
+    stimulus_presentations['post_change'] = stimulus_presentations['is_change'].shift(1)
+    stimulus_presentations['pre_omitted'] = stimulus_presentations['omitted'].shift(-1)
+    stimulus_presentations['post_omitted'] = stimulus_presentations['omitted'].shift(1)
+
+    # add stimulus count within each behavioral trial
+    stimulus_presentations = add_stimulus_count_within_trial_to_stimulus_presentations(stimulus_presentations, trials)
+    # add stimulus count from last change / omission / lick / reward
+    stimulus_presentations = add_stimulus_count_from_last_to_stimulus_presentations(stimulus_presentations, licks, rewards)
+    # add time elapsed since last change / omission / lick / reward
+    stimulus_presentations = add_time_from_last_to_stimulus_presentations(stimulus_presentations, licks, rewards)
+
+    # add column indicating whether a given stimulus presentations could have been a change stimulus
+    # given the known change time distribution and whether or not the mouse licked on a given stimulus (thus aborting and reseting the trial)
+    stimulus_presentations = add_could_change_to_stimulus_presentations(stimulus_presentations, trials, licks)
+
+    return stimulus_presentations

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="brain_observatory_utilities",
-    version="0.1.9",
+    version="0.1.10",
     packages=find_packages(exclude=["tests"]),
     include_package_data=True,
     description="Utilities for analyzing, manipulating and visualizing data for Brain Observatory projects",


### PR DESCRIPTION
[] modified functions to add trials_id to stimulus_presentations - one adds info just for the change and sham change (go/catch) trials, such as whether it was a hit or miss, another adds info across all stimuli that belong to a behavioral trial, such as whether it was aborted or autorewarded
[] adds function to label the stimulus count within each trial
[] modified function to add could_change column which indicates whether a stimulus presentation could have been a change based on known change trial distribution and whether there had already been a change or lick on that trial
[] add functions to get time from last change / omission / lick / reward, or the number of stimuli since the last event
[] add columns for whether a stimulus is pre / post change or omission
[] add functions to implement multiple of the above annotations: `add_timing_info_to_stimulus_presentations` and `add_behavior_info_to_stimulus_presentations` 
