### PR TITLE
Replace 2/3 reward threshold with 2 rewards / min

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ brain_observatory_utilities/utilities/__pycache__/
 brain_observatory_utilities/__pycache__/
 
 *.pyc
+
+*.gz


### PR DESCRIPTION
For some reason, the reward threshold being used to determine the 'engagement' state column that is added to the stimulus_presentations table by the datasets.behavior.data_formatting.annotate_stimulus_presentations() function was using a threshold of 2/3 rewards per minute, which is very lax and counts nearly all trials as belonging to engaged states. This PR modifies the code to use the same code to calculate reward_rate as is used in the AllenSDK, and sets the threshold to call trials "engaged" to 2 rewards per minute, which is the definition used by the SDK when computing behavior performance metrics. 